### PR TITLE
Use transparent background for cams

### DIFF
--- a/style.css
+++ b/style.css
@@ -34,6 +34,8 @@
 }
 .cams__CamWatermark {display:none;}
 
+.cams__Cam {background: #FFFFFF00 !important;}
+
 .hide_usernames .cams__CamHandle {display: none;}
 
 .dark .chat__FeedWrapper {


### PR DESCRIPTION
because people sending widescreen video have ugly grey bars on the top and bottom